### PR TITLE
Update CircleCI with new image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 jobs:
   build:
-    executor: python/default
+    docker:
+      - image: coopachabra/mashey-python-jdk
     parallelism: 5
     steps:
       - checkout


### PR DESCRIPTION
# Description :: Update

CircleCI was failing because we didn't have an image that had a JVM. This fixes that by using a custom image based on CircleCI's python image.

## Type of Update

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Testing
- [ ] Dependency
- [ ] Documentation
- [ ] Breaking Change

## Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes

## Notes

I'm hosting this image on my personal Dockerhub account. We should host it within a Mashey hub instead.