### PR TITLE
Add XcPosTitleAssignment Stream

### DIFF
--- a/tap_xactly/client.py
+++ b/tap_xactly/client.py
@@ -53,7 +53,7 @@ class XactlyClient:
         self._sql.execute(
             "SELECT * "
             + f"FROM {table_name} "
-            + f"WHERE {limit_key} >= {limit_key_value} "
+            + f"WHERE {limit_key} >= '{limit_key_value}' "
             + f"ORDER BY {limit_key}, {primary_key} "
             + f"LIMIT {limit} OFFSET {offset}"
         )

--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -96,6 +96,14 @@ class XcPosRelationsHist(IncrementalStream):  # pylint: disable=too-few-public-m
     replication_key = "MODIFIED_DATE"
 
 
+class XcPosTitleAssignment(IncrementalStream):  # pylint: disable=too-few-public-methods
+    tap_stream_id = "xc_pos_title_assignment"
+    key_properties = ["POS_TITLE_ASSIGNMENT_ID"]
+    object_type = "XC_POS_TITLE_ASSIGNMENT"
+    valid_replication_keys = ["MODIFIED_DATE"]
+    replication_key = "MODIFIED_DATE"
+
+
 class XcAttainmentMeasure(IncrementalStream):  # pylint: disable=too-few-public-methods
     tap_stream_id = "xc_attainment_measure"
     key_properties = ["ATTAINMENT_MEASURE_ID"]
@@ -118,6 +126,7 @@ STREAMS = {
     "xc_pos_rel_type_hist": XcPosRelTypeHist,
     "xc_pos_relations": XcPosRelations,
     "xc_pos_relations_hist": XcPosRelationsHist,
+    "xc_pos_title_assignment": XcPosTitleAssignment,
     "xc_attainment_measure": XcAttainmentMeasure,
     "xc_attainment_measure_criteria": XcAttainmentMeasureCriteria,
 }

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -15,6 +15,8 @@ def test_client_query_database(client):
         "1970-09-28T00:45:22Z",
     )
 
+    assert len(response) == 10
+
     for row in response:
         assert "POS_REL_TYPE_ID" in row
         assert "OBJECT_ID" in row

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,5 +33,4 @@ def client(config):
 
 @pytest.fixture
 def catalog():
-
     return discover()

--- a/tests/streams_test.py
+++ b/tests/streams_test.py
@@ -4,6 +4,7 @@ from tap_xactly.streams import (
     XcPosRelTypeHist,
     XcPosRelations,
     XcPosRelationsHist,
+    XcPosTitleAssignment,
     XcAttainmentMeasure,
     XcAttainmentMeasureCriteria,
     STREAMS,
@@ -26,6 +27,12 @@ def xc_pos_relations_obj(client, state, catalog):
 def xc_pos_relations_hist_obj(client, state, catalog):
     stream = catalog.get_stream(XcPosRelationsHist.tap_stream_id)
     return XcPosRelationsHist(client, state, stream)
+
+
+@pytest.fixture
+def xc_pos_title_assignment_obj(client, state, catalog):
+    stream = catalog.get_stream(XcPosTitleAssignment.tap_stream_id)
+    return XcPosTitleAssignment(client, state, stream)
 
 
 @pytest.fixture
@@ -127,6 +134,35 @@ def test_xc_pos_relations_hist(xc_pos_relations_hist_obj):
         assert "MODIFIED_BY_NAME" in record
         assert "FROM_POS_NAME" in record
         assert "TO_POS_NAME" in record
+
+
+def test_xc_pos_title_assignment(xc_pos_title_assignment_obj):
+    assert xc_pos_title_assignment_obj.tap_stream_id == "xc_pos_title_assignment"
+    assert xc_pos_title_assignment_obj.key_properties == ["POS_TITLE_ASSIGNMENT_ID"]
+    assert xc_pos_title_assignment_obj.object_type == "XC_POS_TITLE_ASSIGNMENT"
+    assert xc_pos_title_assignment_obj.valid_replication_keys == ["MODIFIED_DATE"]
+    assert xc_pos_title_assignment_obj.replication_key == "MODIFIED_DATE"
+
+    assert "xc_pos_title_assignment" in STREAMS
+    assert STREAMS["xc_pos_title_assignment"] == XcPosTitleAssignment
+
+    records = list(xc_pos_title_assignment_obj.sync())
+    assert len(records) > 0
+
+    for record in records:
+        assert "POS_TITLE_ASSIGNMENT_ID" in record
+        assert "VERSION" in record
+        assert "TITLE_ID" in record
+        assert "TITLE_NAME" in record
+        assert "POSITION_ID" in record
+        assert "POSITION_NAME" in record
+        assert "IS_ACTIVE" in record
+        assert "CREATED_DATE" in record
+        assert "CREATED_BY_ID" in record
+        assert "CREATED_BY_NAME" in record
+        assert "MODIFIED_DATE" in record
+        assert "MODIFIED_BY_ID" in record
+        assert "MODIFIED_BY_NAME" in record
 
 
 def test_xc_attainment_measure(xc_attainment_measure_obj):


### PR DESCRIPTION
# Description :: Update

* Adds the `XcPosTitleAssignment` that is responsible for getting data from the `xc_pos_title_assignment` table.
* Fixes an error with the query format of tables. The JayDeBeApi library was silently failing and returning all records instead of whatever the defined limit was.

## Type of Update

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Testing
- [ ] Dependency
- [ ] Documentation
- [ ] Breaking Change

## Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [ ] No Changes
