### PR TITLE
XcPosTitleAssignmentHist Stream

### DIFF
--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -47,7 +47,7 @@ class Stream:  # pylint: disable=too-few-public-methods
                     record_count += 1
                     yield record
 
-                offset += self.limit + 1
+                offset += self.limit
                 last_query_record_count = record_count
 
             except Exception as ex:  # pylint: disable=broad-except

--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -103,6 +103,16 @@ class XcPosTitleAssignment(IncrementalStream):  # pylint: disable=too-few-public
     replication_key = "MODIFIED_DATE"
 
 
+class XcPosTitleAssignmentHist(
+    IncrementalStream
+):  # pylint: disable=too-few-public-methods
+    tap_stream_id = "xc_pos_title_assignment_hist"
+    key_properties = ["POS_TITLE_ASSIGNMENT_ID"]
+    object_type = "XC_POS_TITLE_ASSIGNMENT_HIST"
+    valid_replication_keys = ["MODIFIED_DATE"]
+    replication_key = "MODIFIED_DATE"
+
+
 class XcAttainmentMeasure(IncrementalStream):  # pylint: disable=too-few-public-methods
     tap_stream_id = "xc_attainment_measure"
     key_properties = ["ATTAINMENT_MEASURE_ID"]
@@ -126,6 +136,7 @@ STREAMS = {
     "xc_pos_relations": XcPosRelations,
     "xc_pos_relations_hist": XcPosRelationsHist,
     "xc_pos_title_assignment": XcPosTitleAssignment,
+    "xc_pos_title_assignment_hist": XcPosTitleAssignmentHist,
     "xc_attainment_measure": XcAttainmentMeasure,
     "xc_attainment_measure_criteria": XcAttainmentMeasureCriteria,
 }

--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -32,7 +32,6 @@ class Stream:  # pylint: disable=too-few-public-methods
         )
         offset = 0
         last_query_record_count = self.limit
-        self.client.setup_connection()
         while last_query_record_count >= self.limit:
             try:
                 record_count = 0

--- a/tap_xactly/sync.py
+++ b/tap_xactly/sync.py
@@ -11,6 +11,7 @@ LOGGER = singer.get_logger()
 def sync(config, state, catalog):
     sync_metrics = {"total_records": [], "stream_rps": []}
     client = XactlyClient(config)
+    client.setup_connection()
 
     with Transformer() as transformer:
         for catalog_stream in catalog.get_selected_streams(state):

--- a/tests/streams_test.py
+++ b/tests/streams_test.py
@@ -5,6 +5,7 @@ from tap_xactly.streams import (
     XcPosRelations,
     XcPosRelationsHist,
     XcPosTitleAssignment,
+    XcPosTitleAssignmentHist,
     XcAttainmentMeasure,
     XcAttainmentMeasureCriteria,
     STREAMS,
@@ -33,6 +34,12 @@ def xc_pos_relations_hist_obj(client, state, catalog):
 def xc_pos_title_assignment_obj(client, state, catalog):
     stream = catalog.get_stream(XcPosTitleAssignment.tap_stream_id)
     return XcPosTitleAssignment(client, state, stream)
+
+
+@pytest.fixture
+def xc_pos_title_assignment_hist_obj(client, state, catalog):
+    stream = catalog.get_stream(XcPosTitleAssignmentHist.tap_stream_id)
+    return XcPosTitleAssignmentHist(client, state, stream)
 
 
 @pytest.fixture
@@ -152,6 +159,42 @@ def test_xc_pos_title_assignment(xc_pos_title_assignment_obj):
     for record in records:
         assert "POS_TITLE_ASSIGNMENT_ID" in record
         assert "VERSION" in record
+        assert "TITLE_ID" in record
+        assert "TITLE_NAME" in record
+        assert "POSITION_ID" in record
+        assert "POSITION_NAME" in record
+        assert "IS_ACTIVE" in record
+        assert "CREATED_DATE" in record
+        assert "CREATED_BY_ID" in record
+        assert "CREATED_BY_NAME" in record
+        assert "MODIFIED_DATE" in record
+        assert "MODIFIED_BY_ID" in record
+        assert "MODIFIED_BY_NAME" in record
+
+
+def test_xc_pos_title_assignment_hist(xc_pos_title_assignment_hist_obj):
+    assert (
+        xc_pos_title_assignment_hist_obj.tap_stream_id == "xc_pos_title_assignment_hist"
+    )
+    assert xc_pos_title_assignment_hist_obj.key_properties == [
+        "POS_TITLE_ASSIGNMENT_ID"
+    ]
+    assert (
+        xc_pos_title_assignment_hist_obj.object_type == "XC_POS_TITLE_ASSIGNMENT_HIST"
+    )
+    assert xc_pos_title_assignment_hist_obj.valid_replication_keys == ["MODIFIED_DATE"]
+    assert xc_pos_title_assignment_hist_obj.replication_key == "MODIFIED_DATE"
+
+    assert "xc_pos_title_assignment_hist" in STREAMS
+    assert STREAMS["xc_pos_title_assignment_hist"] == XcPosTitleAssignmentHist
+
+    records = list(xc_pos_title_assignment_hist_obj.sync())
+    assert len(records) > 0
+
+    for record in records:
+        assert "POS_TITLE_ASSIGNMENT_ID" in record
+        assert "VERSION" in record
+        assert "OBJECT_ID" in record
         assert "TITLE_ID" in record
         assert "TITLE_NAME" in record
         assert "POSITION_ID" in record


### PR DESCRIPTION
# Description :: Update

Adds the `XcPosTitleAssignmentHist` stream to get data from the `xc_pos_title_assignment_hist` table.

## Type of Update

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Testing
- [ ] Dependency
- [ ] Documentation
- [ ] Breaking Change

## Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [ ] No Changes
