### PR TITLE
Endpoint :: XcPositionHist

### DIFF
--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -106,6 +106,14 @@ class XcPosition(IncrementalStream):  # pylint: disable=too-few-public-methods
     replication_key = "MODIFIED_DATE"
 
 
+class XcPositionHist(IncrementalStream):  # pylint: disable=too-few-public-methods
+    tap_stream_id = "xc_position_hist"
+    key_properties = ["POSITION_ID"]
+    object_type = "XC_POSITION_HIST"
+    valid_replication_keys = ["MODIFIED_DATE"]
+    replication_key = "MODIFIED_DATE"
+
+
 class XcPosTitleAssignment(IncrementalStream):  # pylint: disable=too-few-public-methods
     tap_stream_id = "xc_pos_title_assignment"
     key_properties = ["POS_TITLE_ASSIGNMENT_ID"]
@@ -169,4 +177,5 @@ STREAMS = {
     "xc_credit": XcCredit,
     "xc_credit_adjustment": XcCreditAdjustment,
     "xc_position": XcPosition,
+    "xc_position_hist": XcPositionHist,
 }

--- a/tests/streams_test.py
+++ b/tests/streams_test.py
@@ -5,6 +5,7 @@ from tap_xactly.streams import (
     XcPosRelations,
     XcPosRelationsHist,
     XcPosition,
+    XcPositionHist,
     XcPosTitleAssignment,
     XcPosTitleAssignmentHist,
     XcAttainmentMeasure,
@@ -31,6 +32,12 @@ def xc_pos_relations_obj(client, state, catalog):
 def xc_position_obj(client, state, catalog):
     stream = catalog.get_stream(XcPosition.tap_stream_id)
     return XcPosition(client, state, stream)
+
+
+@pytest.fixture
+def xc_position_hist_obj(client, state, catalog):
+    stream = catalog.get_stream(XcPositionHist.tap_stream_id)
+    return XcPositionHist(client, state, stream)
 
 
 @pytest.fixture
@@ -145,6 +152,17 @@ def test_xc_position(xc_position_obj):
     assert xc_position_obj.object_type == "XC_POSITION"
     assert xc_position_obj.valid_replication_keys == ["MODIFIED_DATE"]
     assert xc_position_obj.replication_key == "MODIFIED_DATE"
+
+    assert "xc_position" in STREAMS
+    assert STREAMS["xc_position"] == XcPosition
+
+
+def test_xc_position_hist(xc_position_hist_obj):
+    assert xc_position_hist_obj.tap_stream_id == "xc_position_hist"
+    assert xc_position_hist_obj.key_properties == ["POSITION_ID"]
+    assert xc_position_hist_obj.object_type == "XC_POSITION_HIST"
+    assert xc_position_hist_obj.valid_replication_keys == ["MODIFIED_DATE"]
+    assert xc_position_hist_obj.replication_key == "MODIFIED_DATE"
 
     assert "xc_position" in STREAMS
     assert STREAMS["xc_position"] == XcPosition


### PR DESCRIPTION
# Description :: Update

Adds `XcPositionHist` Stream responsible for fetching data from the `xc_position_hist` table.

## Type of Update

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Testing
- [ ] Dependency
- [ ] Documentation
- [ ] Breaking Change

## Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
