### PR TITLE
Endpoint :: XcQuota

### DIFF
--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -174,6 +174,14 @@ class XcCreditHeld(IncrementalStream):  # pylint: disable=too-few-public-methods
     replication_key = "MODIFIED_DATE"
 
 
+class XcQuota(IncrementalStream):  # pylint: disable=too-few-public-methods
+    tap_stream_id = "xc_quota"
+    key_properties = ["QUOTA_ID"]
+    object_type = "XC_QUOTA"
+    valid_replication_keys = ["MODIFIED_DATE"]
+    replication_key = "MODIFIED_DATE"
+
+
 STREAMS = {
     "xc_pos_rel_type_hist": XcPosRelTypeHist,
     "xc_pos_relations": XcPosRelations,
@@ -187,4 +195,5 @@ STREAMS = {
     "xc_credit_held": XcCreditHeld,
     "xc_position": XcPosition,
     "xc_position_hist": XcPositionHist,
+    "xc_quota": XcQuota,
 }

--- a/tests/streams_test.py
+++ b/tests/streams_test.py
@@ -13,6 +13,7 @@ from tap_xactly.streams import (
     XcCredit,
     XcCreditAdjustment,
     XcCreditHeld,
+    XcQuota,
     STREAMS,
 )
 
@@ -87,6 +88,12 @@ def xc_credit_adjustment_obj(client, state, catalog):
 def xc_credit_held_obj(client, state, catalog):
     stream = catalog.get_stream(XcCreditHeld.tap_stream_id)
     return XcCreditHeld(client, state, stream)
+
+
+@pytest.fixture
+def xc_quota_obj(client, state, catalog):
+    stream = catalog.get_stream(XcQuota.tap_stream_id)
+    return XcQuota(client, state, stream)
 
 
 def test_xc_pos_rel_type_hist(xc_pos_rel_type_hist_obj):
@@ -254,3 +261,17 @@ def test_xc_credit_held(xc_credit_held_obj):
     assert xc_credit_held_obj.object_type == "XC_CREDIT_HELD"
     assert xc_credit_held_obj.valid_replication_keys == ["MODIFIED_DATE"]
     assert xc_credit_held_obj.replication_key == "MODIFIED_DATE"
+
+    assert "xc_credit_held" in STREAMS
+    assert STREAMS["xc_credit_held"] == XcCreditHeld
+
+
+def test_xc_quota(xc_quota_obj):
+    assert xc_quota_obj.tap_stream_id == "xc_quota"
+    assert xc_quota_obj.key_properties == ["QUOTA_ID"]
+    assert xc_quota_obj.object_type == "XC_QUOTA"
+    assert xc_quota_obj.valid_replication_keys == ["MODIFIED_DATE"]
+    assert xc_quota_obj.replication_key == "MODIFIED_DATE"
+
+    assert "xc_quota" in STREAMS
+    assert STREAMS["xc_quota"] == XcQuota


### PR DESCRIPTION
# Description :: Update

Adds `XcQuota` Stream responsible for fetching data from the `xc_quota` table.

## Type of Update

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Testing
- [ ] Dependency
- [ ] Documentation
- [ ] Breaking Change

## Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
