### PR TITLE
Endpoint :: XcQuotaAssignment

### DIFF
--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -182,6 +182,14 @@ class XcQuota(IncrementalStream):  # pylint: disable=too-few-public-methods
     replication_key = "MODIFIED_DATE"
 
 
+class XcQuotaAssignment(IncrementalStream):  # pylint: disable=too-few-public-methods
+    tap_stream_id = "xc_quota_assignment"
+    key_properties = ["QUOTA_ASSIGNMENT_ID"]
+    object_type = "XC_QUOTA_ASSIGNMENT"
+    valid_replication_keys = ["MODIFIED_DATE"]
+    replication_key = "MODIFIED_DATE"
+
+
 STREAMS = {
     "xc_pos_rel_type_hist": XcPosRelTypeHist,
     "xc_pos_relations": XcPosRelations,
@@ -196,4 +204,5 @@ STREAMS = {
     "xc_position": XcPosition,
     "xc_position_hist": XcPositionHist,
     "xc_quota": XcQuota,
+    "xc_quota_assignment": XcQuotaAssignment,
 }

--- a/tests/streams_test.py
+++ b/tests/streams_test.py
@@ -14,6 +14,7 @@ from tap_xactly.streams import (
     XcCreditAdjustment,
     XcCreditHeld,
     XcQuota,
+    XcQuotaAssignment,
     STREAMS,
 )
 
@@ -94,6 +95,12 @@ def xc_credit_held_obj(client, state, catalog):
 def xc_quota_obj(client, state, catalog):
     stream = catalog.get_stream(XcQuota.tap_stream_id)
     return XcQuota(client, state, stream)
+
+
+@pytest.fixture
+def xc_quota_assignment_obj(client, state, catalog):
+    stream = catalog.get_stream(XcQuotaAssignment.tap_stream_id)
+    return XcQuotaAssignment(client, state, stream)
 
 
 def test_xc_pos_rel_type_hist(xc_pos_rel_type_hist_obj):
@@ -275,3 +282,14 @@ def test_xc_quota(xc_quota_obj):
 
     assert "xc_quota" in STREAMS
     assert STREAMS["xc_quota"] == XcQuota
+
+
+def test_xc_quota_assignment(xc_quota_assignment_obj):
+    assert xc_quota_assignment_obj.tap_stream_id == "xc_quota_assignment"
+    assert xc_quota_assignment_obj.key_properties == ["QUOTA_ASSIGNMENT_ID"]
+    assert xc_quota_assignment_obj.object_type == "XC_QUOTA_ASSIGNMENT"
+    assert xc_quota_assignment_obj.valid_replication_keys == ["MODIFIED_DATE"]
+    assert xc_quota_assignment_obj.replication_key == "MODIFIED_DATE"
+
+    assert "xc_quota_assignment" in STREAMS
+    assert STREAMS["xc_quota_assignment"] == XcQuotaAssignment


### PR DESCRIPTION
# Description :: Update

Adds `XcQuotaAssignment` Stream responsible for fetching data from the `xc_quota_assignment` table.

## Type of Update

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Testing
- [ ] Dependency
- [ ] Documentation
- [ ] Breaking Change

## Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
