### PR TITLE
Endpoint :: xc_quota_assignment_hist

### DIFF
--- a/tap_xactly/streams.py
+++ b/tap_xactly/streams.py
@@ -206,6 +206,16 @@ class XcQuotaAssignment(IncrementalStream):  # pylint: disable=too-few-public-me
     replication_key = "MODIFIED_DATE"
 
 
+class XcQuotaAssignmentHist(
+    IncrementalStream
+):  # pylint: disable=too-few-public-methods
+    tap_stream_id = "xc_quota_assignment_hist"
+    key_properties = ["QUOTA_ASSIGNMENT_ID"]
+    object_type = "XC_QUOTA_ASSIGNMENT_HIST"
+    valid_replication_keys = ["MODIFIED_DATE"]
+    replication_key = "MODIFIED_DATE"
+
+
 class XcPosHierarchy(IncrementalStream):  # pylint: disable=too-few-public-methods
     tap_stream_id = "xc_pos_hierarchy"
     key_properties = ["POS_HIERARCHY_ID"]
@@ -239,6 +249,7 @@ STREAMS = {
     "xc_quota": XcQuota,
     "xc_credit_type": XcCreditType,
     "xc_quota_assignment": XcQuotaAssignment,
+    "xc_quota_assignment_hist": XcQuotaAssignmentHist,
     "xc_pos_hierarchy": XcPosHierarchy,
     "xc_pos_hierarchy_hist": XcPosHierarchyHist,
 }

--- a/tests/streams_test.py
+++ b/tests/streams_test.py
@@ -17,6 +17,7 @@ from tap_xactly.streams import (
     XcCreditHeld,
     XcQuota,
     XcQuotaAssignment,
+    XcQuotaAssignmentHist,
     XcCreditTotals,
     XcCreditType,
     STREAMS,
@@ -117,6 +118,12 @@ def xc_credit_type_obj(client, state, catalog):
 def xc_quota_assignment_obj(client, state, catalog):
     stream = catalog.get_stream(XcQuotaAssignment.tap_stream_id)
     return XcQuotaAssignment(client, state, stream)
+
+
+@pytest.fixture
+def xc_quota_assignment_hist_obj(client, state, catalog):
+    stream = catalog.get_stream(XcQuotaAssignmentHist.tap_stream_id)
+    return XcQuotaAssignmentHist(client, state, stream)
 
 
 @pytest.fixture
@@ -343,6 +350,17 @@ def test_xc_quota_assignment(xc_quota_assignment_obj):
 
     assert "xc_quota_assignment" in STREAMS
     assert STREAMS["xc_quota_assignment"] == XcQuotaAssignment
+
+
+def test_xc_quota_assignment_hist(xc_quota_assignment_hist_obj):
+    assert xc_quota_assignment_hist_obj.tap_stream_id == "xc_quota_assignment_hist"
+    assert xc_quota_assignment_hist_obj.key_properties == ["QUOTA_ASSIGNMENT_ID"]
+    assert xc_quota_assignment_hist_obj.object_type == "XC_QUOTA_ASSIGNMENT_HIST"
+    assert xc_quota_assignment_hist_obj.valid_replication_keys == ["MODIFIED_DATE"]
+    assert xc_quota_assignment_hist_obj.replication_key == "MODIFIED_DATE"
+
+    assert "xc_quota_assignment_hist" in STREAMS
+    assert STREAMS["xc_quota_assignment_hist"] == XcQuotaAssignmentHist
 
 
 def test_xc_pos_hierarchy(xc_pos_hierarchy_obj):


### PR DESCRIPTION
# Description :: Update

Adds `XcQuotaAssignmentHist` Stream responsible for fetching data from the `xc_quota_assignment_hist` table.

## Type of Update

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Testing
- [ ] Dependency
- [ ] Documentation
- [ ] Breaking Change

## Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
